### PR TITLE
fix:handle semantic_location

### DIFF
--- a/publish_mqtt.py
+++ b/publish_mqtt.py
@@ -93,6 +93,7 @@ def publish_device_state(
     accuracy = location_data.get("accuracy")
     altitude = location_data.get("altitude")
     timestamp = location_data.get("timestamp")
+    semantic_location = location_data.get("semantic_location")
 
     if timestamp:
         if isinstance(timestamp, (int, float)):
@@ -112,23 +113,44 @@ def publish_device_state(
         # If no timestamp is provided, use the current time.
         last_updated_iso = datetime.now(timezone.utc).isoformat()
 
+    # Determine state based on semantic_location
+    if semantic_location:
+        state = "home"
+        logger.info(f"Device '{device_name}' has semantic location '{semantic_location}', setting state to 'home'.")
+    else:
+        state = "unknown"
+
     # Publish state (home/not_home/unknown)
-    state = "unknown"
     client.publish(f"{base_topic}/state", state)
 
     # Publish attributes
     attributes = {
-        "latitude": lat,
-        "longitude": lon,
-        "altitude": altitude,
-        "gps_accuracy": accuracy,
         "source_type": "gps",
         "last_updated": last_updated_iso,
     }
-    logger.info(
-        f"Publishing location for '{device_name}' (ID: {canonic_id}): "
-        f"lat={lat}, lon={lon}, accuracy={accuracy}"
-    )
+    
+    # Add GPS attributes if they exist and are not None/empty
+    if lat is not None:
+        attributes["latitude"] = lat
+    if lon is not None:
+        attributes["longitude"] = lon
+    if altitude is not None:
+        attributes["altitude"] = altitude
+    if accuracy is not None:
+        attributes["gps_accuracy"] = accuracy
+    
+    # Add semantic_location to attributes if it exists
+    if semantic_location:
+        attributes["semantic_location"] = semantic_location
+        logger.info(
+            f"Publishing location for '{device_name}' (ID: {canonic_id}) with semantic location: {semantic_location}"
+        )
+    else:
+        logger.info(
+            f"Publishing location for '{device_name}' (ID: {canonic_id}): "
+            f"lat={lat}, lon={lon}, accuracy={accuracy}"
+        )
+    
     r = client.publish(f"{base_topic}/attributes", json.dumps(attributes))
     return r
 
@@ -177,8 +199,16 @@ def main():
 
                         # Get and publish location data
                         location_data = get_location_data_for_device(fcm_receiver, canonic_id, device_name)
-                        if not location_data or not all(k in location_data for k in ['latitude', 'longitude']):
-                            logger.warning(f"Incomplete or missing location data for '{device_name}'. Skipping.")
+                        if not location_data:
+                            logger.warning(f"No location data received for '{device_name}'. Skipping.")
+                            continue
+                        
+                        # Check if we have either GPS coordinates or semantic location
+                        has_gps = location_data.get('latitude') is not None and location_data.get('longitude') is not None
+                        has_semantic = location_data.get('semantic_location') is not None
+                        
+                        if not has_gps and not has_semantic:
+                            logger.warning(f"No usable location data (GPS or semantic) for '{device_name}'. Skipping.")
                             continue
 
                         msg_info = publish_device_state(client, device_name, canonic_id, location_data)


### PR DESCRIPTION
Updated publish_mqtt.py script to retrieve  and set the mqtt sensor state to . Semantic location is passed as an attribute. When Semantic location is received, GPS coordinates are not provided. Updated script to check if gps coordinates exist, otherwise do not publish them.

If the semantic_location is no provided, the state is still being set to `unknown` and Home Assistant is calculating it based on the GPS coordinates. I'm not sure if this is ideal, but I kept it as is.

I think the logic behind the below makes sense, you're welcome to optimise this as I am _not a dev_ and therefore the code is probably not great.

See below from my testing today (I made sure to take one of my trackers while I was away, to ensure I could test the scenario).

(in this scenario the script didn't retrieve a semantic location home, but the GPS coordinates are still home, so Home Assistant updated the state to `home`).
<img width="1544" height="258" alt="Screenshot_20250723_075245" src="https://github.com/user-attachments/assets/a663d202-b400-4f42-8103-6f2d52f20ebd" />

Semantic location being used to set state to `home`, no GPS coordinates.
<img width="1556" height="264" alt="Screenshot_20250723_093404" src="https://github.com/user-attachments/assets/d6f974f7-5056-4c7d-bbb3-0ed1e91d7bb5" />

Semantic location being used to set state to `home`, no GPS coordinates.
<img width="1556" height="145" alt="Screenshot_20250723_093420" src="https://github.com/user-attachments/assets/057620dd-05fe-44b0-b640-d806d04a7be9" />

GPS coordinates being used by Home Assistant to set the state to away.
<img width="703" height="1463" alt="Screenshot_20250723_135753" src="https://github.com/user-attachments/assets/e31ae337-e5b4-45ec-a010-42bf5f38f078" />
